### PR TITLE
Extract start method

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 
 	db.AutoMigrate(&models.Cron{})
 	sc := models.NewScheduler()
-	sc.Cron.Start()
+	sc.Start()
 
 	env := &handlers.Env{db, sc}
 

--- a/models/scheduler.go
+++ b/models/scheduler.go
@@ -28,6 +28,10 @@ func NewScheduler() *Scheduler {
 	}
 }
 
+func (s *Scheduler) Start() {
+	s.Cron.Start()
+}
+
 func (s *Scheduler) Create(cron *Cron) error {
 	runJob := func(fn retriable, retries int) {
 		_, err := http.Get(cron.Url)


### PR DESCRIPTION
Extract `start` method for avoiding Shotgun Surgery code smell